### PR TITLE
Depend on helm instead of helm-core

### DIFF
--- a/helm-osx-app.el
+++ b/helm-osx-app.el
@@ -4,7 +4,7 @@
 
 ;; Author: Xu Chunyang
 ;; Homepage: https://github.com/xuchunyang/helm-osx-app
-;; Package-Requires: ((emacs "25.1") (helm-core "3.0"))
+;; Package-Requires: ((emacs "25.1") (helm "3.0"))
 ;; Created: 2019/7/7 深夜
 ;; Version: 1.0
 


### PR DESCRIPTION
helm-adaptive-sort and helm-adaptive-mode are defined in helm instead of helm-core.

ref: https://github.com/NixOS/nixpkgs/issues/335442